### PR TITLE
Add basic battle event queue and menu fixes

### DIFF
--- a/src/main/java/Game/Characters/EnemyDatabase.java
+++ b/src/main/java/Game/Characters/EnemyDatabase.java
@@ -37,4 +37,13 @@ public class EnemyDatabase {
         }
         throw new RolladieException("Enemy not found!");
     }
+
+    /**
+     * Selects enemy by given index
+     * @param index
+     * @return Enemy object
+     */
+    public static Enemy getEnemyByIndex(int index) {
+        return enemyList.get(index);
+    }
 }

--- a/src/main/java/Game/Events/Battle/Battle.java
+++ b/src/main/java/Game/Events/Battle/Battle.java
@@ -3,6 +3,7 @@ package Game.Events.Battle;
 import Exceptions.RolladieException;
 import Functionalities.UI.BattleUI;
 import Game.Characters.Enemy;
+import Game.Characters.EnemyDatabase;
 import Game.Characters.Player;
 import Game.Events.Event;
 
@@ -39,10 +40,10 @@ public class Battle extends Event {
     }
 
 
-    public Battle(Player player) {
+    public Battle(Player player, int turn) {
         super(player);
         int[] enemyHealth = {50};
-        this.enemy = new Enemy(enemyHealth, 15, 5, "Goblin");
+        this.enemy = EnemyDatabase.getEnemyByIndex(turn);
         this.hasWon = false;
     }
 

--- a/src/main/java/Game/Game.java
+++ b/src/main/java/Game/Game.java
@@ -76,7 +76,7 @@ public class Game {
     private Queue<Event> generateEventQueue() {
         Queue<Event> eventsQueue = new LinkedList<>();
         for (int i = 0; i < MAX_NUMBER_OF_EVENTS; i++) {
-            eventsQueue.add(generateEvent());
+            eventsQueue.add(generateEvent(i));
         }
         return eventsQueue;
     }
@@ -88,8 +88,8 @@ public class Game {
      * Idea: Interleaving the event queue with Battle and Non-Battle events
      * @return Event
      */
-    private Event generateEvent() {
-        return new Battle(this.player);
+    private Event generateEvent(int turn) {
+        return new Battle(this.player, turn);
     }
 
     /**

--- a/src/main/java/Game/Menu/MenuSystem.java
+++ b/src/main/java/Game/Menu/MenuSystem.java
@@ -14,9 +14,9 @@ public class MenuSystem {
     public MenuSystem() {
         try {
             terminal = new DefaultTerminalFactory().createTerminal();
-            terminal.enterPrivateMode();
-            terminal.clearScreen();
-            terminal.setCursorVisible(false);
+            // terminal.enterPrivateMode();
+            // terminal.clearScreen();
+            // terminal.setCursorVisible(false);
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -34,6 +34,15 @@ public class MenuSystem {
             boolean shouldExit = action.execute();
             if (shouldExit) return true;
         }
+    }
+
+    public void reinitializeTerminal() throws IOException {
+        // Close old terminal
+        if (this.terminal != null) {
+            this.terminal.close();
+        }
+        // Create fresh terminal instance
+        this.terminal = new DefaultTerminalFactory().createTerminal();
     }
 
     public void exitPrivateMode() {

--- a/src/main/java/Game/Menu/TerminalUtils.java
+++ b/src/main/java/Game/Menu/TerminalUtils.java
@@ -3,8 +3,43 @@ package Game.Menu;
 import java.io.IOException;
 
 public class TerminalUtils {
+    private static String originalSettings;
+    
+    public static void saveTerminalState() throws IOException, InterruptedException {
+        if (!isWindows()) {
+            Process p = new ProcessBuilder("sh", "-c", "stty -g </dev/tty").start();
+            originalSettings = new String(p.getInputStream().readAllBytes()).trim();
+        }
+    }
+
+    public static void resetTerminalOverkill() throws IOException, InterruptedException {
+        if (isWindows()) {
+            new ProcessBuilder("cmd", "/c", "cls").start().waitFor();
+        } else {
+            new ProcessBuilder("sh", "-c", "reset").start().waitFor();
+        }
+    }
+
     public static void resetTerminal() throws IOException, InterruptedException {
-        // Execute 'stty sane' to restore terminal defaults
-        new ProcessBuilder("sh", "-c", "stty sane </dev/tty").start().waitFor();
+        if (isWindows()) {
+            // Windows-specific reset
+            new ProcessBuilder("cmd", "/c", "cls").start().waitFor();
+        } else {
+            // Restore original settings AND ensure clean slate
+            new ProcessBuilder("sh", "-c", "stty " + originalSettings + " </dev/tty && stty sane").start().waitFor();
+            System.out.print("\033[?25h\033[0m"); // Show cursor and reset formatting
+        }
+    }
+
+    public static void prepareForLanterna() throws IOException, InterruptedException {
+        if (!isWindows()) {
+            // Full Lanterna preparation including raw mode
+            new ProcessBuilder("sh", "-c", "stty -echo -icanon -isig -ixon -ixoff").start().waitFor();
+        }
+        System.out.print("\033[?25l"); // Hide cursor
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase().contains("win");
     }
 }

--- a/src/main/java/Game/RollDice.java
+++ b/src/main/java/Game/RollDice.java
@@ -40,8 +40,7 @@ public class RollDice {
         first_dice = rand.nextInt(MAX - MIN + 1) + MIN;
         second_dice = rand.nextInt(MAX - MIN + 1) + MIN;
 
-        printDiceImage(first_dice);
-        printDiceImage(second_dice);
+        printDiceImages(first_dice, second_dice);
 
         return first_dice + second_dice;
     }
@@ -73,6 +72,35 @@ public class RollDice {
             break;
         }
     }
+
+    /**
+     * Prints a list of dices side-by-side
+     * 
+     * @param diceValues list of integer values representing rolled dice value
+     */
+    public static void printDiceImages(int... diceValues) {
+        // Store dice faces as 2D string arrays (each die is 5x7 or similar)
+        String[][] diceFaces = {
+            UI.DIE_FACE_1.split("\n"),
+            UI.DIE_FACE_2.split("\n"),
+            UI.DIE_FACE_3.split("\n"),
+            UI.DIE_FACE_4.split("\n"),
+            UI.DIE_FACE_5.split("\n"),
+            UI.DIE_FACE_6.split("\n")
+        };
+    
+        // Get the height of the dice face
+        int faceHeight = diceFaces[0].length; 
+    
+        // Print the dice line by line
+        for (int row = 0; row < faceHeight; row++) {
+            for (int diceValue : diceValues) {
+                System.out.print(diceFaces[diceValue - 1][row] + "  "); // Print each line with spacing
+            }
+            System.out.println(); // Move to next row
+        }
+    }
+    
 
     /**
      * Return the effect of rolling dice.


### PR DESCRIPTION
#57 Implemented basic enemy queue for varied enemy encounters. Progression is fixed (i.e. play-throughs all experience the same set of enemies). Use flee currently to shuffle through the list.

Also fixed some issues with the main menu overlapping with printed text from the previous game instance.

Errors still present:
- Selecting new game immediately after completing one will cause a crash. The second game starts properly but if "attack" is chosen, the game errors at updating the health bars for the characters. Probably some variable being reused and not properly reinitialised.